### PR TITLE
fix: data from wiki (datatypes label) are now extracted without modif…

### DIFF
--- a/lib/wiki.js
+++ b/lib/wiki.js
@@ -174,7 +174,7 @@ Self.parseDataTaype = function (htmlString, cb) {
         ? data.best_practice_for_sharing_this_type_of_data
         : '',
       'mostSuitableRepositories': data.most_suitable_repositories ? data.most_suitable_repositories : '',
-      'label': Self.toTitleCase(h2.text().split('- ').slice(-1)[0])
+      'label': h2.text().split('- ').slice(-1)[0]
     };
   dataType.count = dataTypesCounts[dataType.id] ? dataTypesCounts[dataType.id] : 0;
   return cb(null, dataType);


### PR DESCRIPTION
…ication to improve RepoRecommender matching (https://github.com/DataSeer/RepoRecommender/issues/11). Datatypes must be same in wiki datatypes pages and in .csv files